### PR TITLE
Umbrel support

### DIFF
--- a/Add2WL-for-Invidious.user.js
+++ b/Add2WL-for-Invidious.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Add to Watch Later for Invidious
 // @namespace      https://github.com/WalsGit
-// @version        1.1.1
+// @version        1.2
 // @description    Adds an "Add to Watch Later" button on video thumbnails for Invidious
 // @author         Wa!id
 // @license        MIT
@@ -31,8 +31,8 @@
 // @match          *://yt.cdaut.de/*
 // @match          *://invidious.privacydev.net/*
 // @match          *://iv.melmac.space/*
-// @include        http://umbrel.local:3420/*
-// @include        https://umbrel.local:3420/*
+// @match          *://umbrel.local:3420/*
+// @match          *://umbrel:3420/*
 // @downloadURL    https://github.com/WalsGit/Add2WL-for-Invidious/raw/main/Add2WL-for-Invidious.user.js
 // @updateURL      https://github.com/WalsGit/Add2WL-for-Invidious/raw/main/Add2WL-for-Invidious.user.js
 // @supportURL     https://github.com/WalsGit/Add2WL-for-Invidious/issues
@@ -85,7 +85,7 @@
     let ChangeDefaultWLPLID = false;
 
     const protocol = window.location.protocol;
-    const IVinstance = protocol + "//" + window.location.hostname;
+    const IVinstance = protocol + "//" + window.location.host;
     const currentPageURL = window.location.href;
     const playlistsPageURL = IVinstance + "/feed/playlists";
 

--- a/Add2WL-for-Invidious.user.js
+++ b/Add2WL-for-Invidious.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           Add to Watch Later for Invidious
 // @namespace      https://github.com/WalsGit
-// @version        1.1
+// @version        1.1.1
 // @description    Adds an "Add to Watch Later" button on video thumbnails for Invidious
 // @author         Wa!id
 // @license        MIT
@@ -31,6 +31,8 @@
 // @match          *://yt.cdaut.de/*
 // @match          *://invidious.privacydev.net/*
 // @match          *://iv.melmac.space/*
+// @include        http://umbrel.local:3420/*
+// @include        https://umbrel.local:3420/*
 // @downloadURL    https://github.com/WalsGit/Add2WL-for-Invidious/raw/main/Add2WL-for-Invidious.user.js
 // @updateURL      https://github.com/WalsGit/Add2WL-for-Invidious/raw/main/Add2WL-for-Invidious.user.js
 // @supportURL     https://github.com/WalsGit/Add2WL-for-Invidious/issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.2
+Release date : May 6th, 2024
+
+* [NEW] added support for Umbrel self-hosted IV instances & any manually added instances mapped to a port other than 80 (h/t [@anthony-robin] (https://github.com/anthony-robin) [Issue #1] (https://github.com/WalsGit/Add2WL-for-Invidious/issues/1))
+
 ## 1.1
 Release date : May 3rd, 2024
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Note that the script will also work with the `http` protocol as of version 1.1.
 ## How to install
 In Tampermonkey, go to the **Utilities** tab and paste this URL https://github.com/WalsGit/Add2WL-for-Invidious/raw/main/Add2WL-for-Invidious.user.js in the **Import from URL** field and click on install.
 
-The script is also available on Greasyfork at https://greasyfork.org/en/scripts/494002-add-to-watch-later-for-invidious 
+The script is also available on Greasyfork at https://greasyfork.org/en/scripts/494002-add-to-watch-later-for-invidious and on OpenUserJS at https://openuserjs.org/scripts/Walsgit/Add_to_Watch_Later_for_Invidious
 
 ## How it works
  1. Go and login to your Invidious instance


### PR DESCRIPTION
Added support for Umbrel self-hosted IV instances and for any other user added instances that are targeting a port other than 80.